### PR TITLE
Modernize Docker build

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Aktuelle Version: 1.04
 ## Server
 * Java EE - Serversoftware (Benötigt einen Application-Server wie bspw. glassfish)
 * MySQL-Datenbank
+* Docker-Image basiert nun auf OpenJDK&nbsp;17
 
 Mittlerweile würde ich das in NodeJS schreiben. Das Passwort-Hashing geht auch besser.
 

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,5 @@
+# Exclude development artifacts from Docker build context
+src/
+build/
+test/
+start.bat

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:8-jre-slim
+# Use a modern Java runtime
+FROM openjdk:17-jre-slim
 WORKDIR /app
 COPY . /app
 RUN sed -i 's/^mysql_host=.*/mysql_host=db/' config.ini


### PR DESCRIPTION
## Summary
- update server Dockerfile to OpenJDK 17
- document new Java version
- add `.dockerignore` to slim down Docker build context

## Testing
- `docker build` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684c97be6614832895af9bfa24db88e1