### PR TITLE
Improve DB config for Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ docker-compose up
 
 gestartet werden. Die MySQL-Datenbank wird dabei automatisch mit `arenawars.sql` initialisiert und der Spielserver läuft anschließend unter Port 8081.
 
+Die Zugangsdaten zur Datenbank können über Umgebungsvariablen angepasst werden. `docker-compose.yml` definiert dazu `MYSQL_HOST`, `MYSQL_PORT`, `MYSQL_USER`, `MYSQL_PASSWORD` und `MYSQL_NAME`. Diese Werte werden vom Server beim Start eingelesen und überschreiben die Angaben aus `server/config.ini`.
+
 ## Client
 
 * WebApp mit JQuery und JQueryUI

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,5 +11,11 @@ services:
     build: ./server
     depends_on:
       - db
+    environment:
+      - MYSQL_HOST=db
+      - MYSQL_PORT=3306
+      - MYSQL_USER=root
+      - MYSQL_PASSWORD=secret
+      - MYSQL_NAME=arenawars
     ports:
       - "8081:8081"

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,6 +2,10 @@
 FROM openjdk:17-jre-slim
 WORKDIR /app
 COPY . /app
-RUN sed -i 's/^mysql_host=.*/mysql_host=db/' config.ini
+ENV MYSQL_HOST=db \
+    MYSQL_PORT=3306 \
+    MYSQL_USER=root \
+    MYSQL_PASSWORD=secret \
+    MYSQL_NAME=arenawars
 EXPOSE 8081
 ENTRYPOINT ["java","-jar","/app/awserver.jar"]

--- a/server/src/content/Init.java
+++ b/server/src/content/Init.java
@@ -66,8 +66,30 @@ public class Init { // Initialisierungsklasse
 		}
 		br.close();
 		
-		System.out.println("* Konfigurationsdatei eingelesen");
-		MySQL.setConfig(config.get("mysql_host"), config.get("mysql_user"), config.get("mysql_password"), config.get("mysql_name"), new Integer(config.get("mysql_port")));
+                System.out.println("* Konfigurationsdatei eingelesen");
+
+                // Allow overriding database settings via environment variables
+                String env;
+                env = System.getenv("MYSQL_HOST");
+                if(env != null) config.put("mysql_host", env);
+                env = System.getenv("MYSQL_USER");
+                if(env != null) config.put("mysql_user", env);
+                env = System.getenv("MYSQL_PASSWORD");
+                if(env != null) config.put("mysql_password", env);
+                env = System.getenv("MYSQL_NAME");
+                if(env != null) config.put("mysql_name", env);
+                env = System.getenv("MYSQL_PORT");
+                if(env != null) config.put("mysql_port", env);
+                env = System.getenv("WS_PORT");
+                if(env != null) config.put("ws_port", env);
+
+                MySQL.setConfig(
+                        config.get("mysql_host"),
+                        config.get("mysql_user"),
+                        config.get("mysql_password"),
+                        config.get("mysql_name"),
+                        new Integer(config.get("mysql_port"))
+                );
 		db = new MySQL();
 		
 		System.out.println("* MySQL-Verbindung hergestellt");


### PR DESCRIPTION
## Summary
- inject DB settings via env vars instead of editing config file
- allow Init to read database settings from environment variables
- document environment variables in README
- pass DB settings to server container via docker-compose

## Testing
- `javac server/test/content/DatahandlerTest.java -classpath server/dependencies/mysql-connector-java-5.1.38.jar` *(fails: package org.junit does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_684c9cd76964832891ea2344b7656731