### PR TITLE
Containerize server with DB startup check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM openjdk:8-jre
+WORKDIR /opt/arenawars
+COPY server/awserver.jar ./
+COPY server/config.ini ./
+COPY server/dependencies/ ./dependencies
+COPY start.sh ./
+RUN chmod +x start.sh
+CMD ["./start.sh"]
+

--- a/README.md
+++ b/README.md
@@ -38,3 +38,20 @@ Dominik Höltgen (Planung, Grafiken, Code)
 **Extern**
 
 Marjan Markelj (Musik + Sound)
+
+## Docker-Setup
+
+Mit Docker und docker-compose lässt sich das Projekt unkompliziert starten. Die bereitgestellte `docker-compose.yml` richtet eine MariaDB-Datenbank (Version 10.1), den Java-Server sowie einen kleinen nginx-Container für die statischen Client-Dateien ein.
+
+1. Docker und docker-compose installieren.
+2. Im Projektverzeichnis den folgenden Befehl ausführen:
+   ```bash
+   docker-compose up --build
+   ```
+3. Der Client ist anschließend unter http://localhost:8080 erreichbar; der Websocket-Server läuft auf Port 8081.
+
+Beim ersten Start wird das SQL-Skript `arenawars.sql` automatisch in die Datenbank importiert.
+Der Server greift per Standard-Konfigurationsdatei `server/config.ini` auf die
+Datenbank zu. Darin ist `mysql_host=db` konfiguriert, da der
+datenbank-Container diesen Servicenamen trägt. Das Standardpasswort lautet
+`example` (siehe `docker-compose.yml`).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.7'
+services:
+  db:
+    image: mariadb:10.1
+    environment:
+      MYSQL_ROOT_PASSWORD: example
+      MYSQL_DATABASE: arenawars
+    volumes:
+      - ./arenawars.sql:/docker-entrypoint-initdb.d/arenawars.sql:ro
+    ports:
+      - "3306:3306"
+
+  server:
+    build: .
+    depends_on:
+      - db
+    ports:
+      - "8081:8081"
+    volumes:
+      - ./server/config.ini:/opt/arenawars/config.ini
+
+  client:
+    image: nginx:alpine
+    volumes:
+      - ./client:/usr/share/nginx/html:ro
+    ports:
+      - "8080:80"

--- a/server/config.ini
+++ b/server/config.ini
@@ -1,6 +1,6 @@
-mysql_host=localhost
+mysql_host=db
 mysql_user=root
-mysql_password=
+mysql_password=example
 mysql_name=arenawars
 mysql_port=3306
 ws_port=8081

--- a/server/src/content/Init.java
+++ b/server/src/content/Init.java
@@ -92,8 +92,8 @@ public class Init { // Initialisierungsklasse
 
 	}
 
-	private static void runServer() throws Exception {
-		  Server server = new Server("localhost", new Integer(config.get("ws_port")), "/arenawars", null, Websocket.class);
+        private static void runServer() throws Exception {
+                  Server server = new Server("0.0.0.0", new Integer(config.get("ws_port")), "/arenawars", null, Websocket.class);
 		 		System.out.println("starting...");
 		 		server.start();
 				System.out.println("started!");

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+HOST="${MYSQL_HOST:-db}"
+PORT="${MYSQL_PORT:-3306}"
+# Wait for MySQL to be available
+until bash -c "</dev/tcp/$HOST/$PORT" 2>/dev/null; do
+  echo "Waiting for MySQL at $HOST:$PORT..."
+  sleep 2
+done
+exec java -jar awserver.jar


### PR DESCRIPTION
## Summary
- add a startup script that waits for the DB container to be reachable
- update Dockerfile to use the script as entrypoint

## Testing
- `docker --version` *(fails: command not found)*
- `docker-compose --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d96aeca808328999cd3c455835fee