### PR TITLE
Single container Docker setup with source build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,22 @@
-FROM openjdk:8-jre
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    openjdk-8-jdk \
+    mariadb-server \
+    nginx && \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /opt/arenawars
-COPY server/awserver.jar ./
-COPY server/config.ini ./
-COPY server/dependencies/ ./dependencies
-CMD ["java", "-jar", "awserver.jar"]
+
+COPY server/src ./src
+COPY server/dependencies ./dependencies
+COPY server/config.ini ./config.ini
+COPY arenawars.sql ./arenawars.sql
+COPY client /usr/share/nginx/html
+COPY run.sh /run.sh
+
+EXPOSE 80 8081
+
+CMD ["/run.sh"]

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Marjan Markelj (Musik + Sound)
 
 ## Docker-Setup
 
-Mit Docker und docker-compose lässt sich das Projekt unkompliziert starten. Die bereitgestellte `docker-compose.yml` richtet eine MariaDB-Datenbank (Version 10.1), den Java-Server sowie einen kleinen nginx-Container für die statischen Client-Dateien ein.
+Mit Docker und `docker-compose` lässt sich das Projekt unkompliziert starten. Inzwischen laufen Server, Client und die Datenbank in **einem** Container.
 
 1. Docker und docker-compose installieren.
 2. Im Projektverzeichnis den folgenden Befehl ausführen:
@@ -50,4 +50,4 @@ Mit Docker und docker-compose lässt sich das Projekt unkompliziert starten. Die
    ```
 3. Der Client ist anschließend unter http://localhost:8080 erreichbar; der Websocket-Server läuft auf Port 8081.
 
-Beim ersten Start wird das SQL-Skript `arenawars.sql` automatisch in die Datenbank importiert.
+Beim ersten Start wird das SQL-Skript `arenawars.sql` automatisch in die Datenbank importiert und der Java-Code direkt aus den Quellen kompiliert.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,27 +1,13 @@
 version: '3.7'
 services:
-  db:
-    image: mariadb:10.1
-    environment:
-      MYSQL_ROOT_PASSWORD: example
-      MYSQL_DATABASE: arenawars
-    volumes:
-      - ./arenawars.sql:/docker-entrypoint-initdb.d/arenawars.sql:ro
-    ports:
-      - "3306:3306"
-
-  server:
+  app:
     build: .
-    depends_on:
-      - db
-    ports:
-      - "8081:8081"
-    volumes:
-      - ./server/config.ini:/opt/arenawars/config.ini
-
-  client:
-    image: nginx:alpine
-    volumes:
-      - ./client:/usr/share/nginx/html:ro
     ports:
       - "8080:80"
+      - "8081:8081"
+    volumes:
+      - ./server/src:/opt/arenawars/src
+      - ./server/dependencies:/opt/arenawars/dependencies
+      - ./server/config.ini:/opt/arenawars/config.ini
+      - ./client:/usr/share/nginx/html
+      - ./arenawars.sql:/opt/arenawars/arenawars.sql

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+# Start MariaDB
+mysqld_safe &
+# wait for DB
+until mysqladmin ping --silent; do
+  sleep 1
+done
+# initialize database if first run
+if [ ! -f /var/lib/mysql/.initialized ]; then
+  mysql -u root -e "CREATE DATABASE IF NOT EXISTS arenawars;"
+  mysql -u root arenawars < /opt/arenawars/arenawars.sql
+  touch /var/lib/mysql/.initialized
+fi
+# compile java sources
+mkdir -p /opt/arenawars/build
+javac -d /opt/arenawars/build -classpath "/opt/arenawars/dependencies/*" /opt/arenawars/src/content/*.java
+# start websocket server
+java -cp "/opt/arenawars/build:/opt/arenawars/dependencies/*" content.Init &
+# run nginx in foreground
+exec nginx -g 'daemon off;'


### PR DESCRIPTION
## Summary
- consolidate all services (server, client, DB) in a single Docker image
- compile Java sources on container startup instead of using the jar
- add a startup script that initializes the database and launches all components
- simplify docker-compose configuration for the new image
- update README instructions

## Testing
- `bash -n run.sh`

------
https://chatgpt.com/codex/tasks/task_e_685da4b04fec8328b83f867367ae2c5f