### PR TITLE
Document server build process and add guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Guidelines for Contributors
+
+This repository contains a Java based WebSocket server (in `server/`) and a
+static client (in `client/`).
+
+## Building the server
+- Run `./server/build.sh` whenever Java sources or dependencies change. The
+  script compiles the code with Java 8 compatibility and assembles
+  `server/awserver.jar` including all dependencies.
+- Use this script as the project test step.
+
+## General
+- Keep existing LF line endings.
+- Write commit messages in English.

--- a/README.md
+++ b/README.md
@@ -51,3 +51,17 @@ Mit Docker und docker-compose lässt sich das Projekt unkompliziert starten. Die
 3. Der Client ist anschließend unter http://localhost:8080 erreichbar; der Websocket-Server läuft auf Port 8081.
 
 Beim ersten Start wird das SQL-Skript `arenawars.sql` automatisch in die Datenbank importiert.
+
+## Server Build
+
+Die Datei `server/awserver.jar` ist bereits vorkompiliert. Wenn Änderungen am
+Java-Code vorgenommen werden, lässt sich ein neues JAR mit dem Skript
+`server/build.sh` erstellen:
+
+```bash
+cd server
+./build.sh
+```
+
+Das Skript kompiliert alle Klassen mit Java 8-Kompatibilität und bundelt die
+benötigten Bibliotheken zu einem ausführbaren Fat‑JAR.

--- a/server/build.sh
+++ b/server/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+cd "$(dirname "$0")"
+BUILD_DIR="build/classes"
+MANIFEST="MANIFEST.MF"
+OUT_JAR="awserver.jar"
+rm -rf "$BUILD_DIR" "$OUT_JAR" "$MANIFEST"
+mkdir -p "$BUILD_DIR"
+javac -encoding ISO-8859-1 --release 8 -classpath "dependencies/*:dependencies/tyrus/*" -d "$BUILD_DIR" src/content/*.java
+cat > "$MANIFEST" <<EOM
+Manifest-Version: 1.0
+Class-Path: .
+Main-Class: content.Init
+EOM
+jar cfm "$OUT_JAR" "$MANIFEST" -C "$BUILD_DIR" .
+TMP_DIR=$(mktemp -d)
+ABS_DIR=$(pwd)
+for dep in dependencies/*.jar dependencies/tyrus/*.jar; do
+  (cd "$TMP_DIR" && jar xf "$ABS_DIR/$dep")
+  rm -rf "$TMP_DIR"/META-INF
+done
+jar uf "$OUT_JAR" -C "$TMP_DIR" .
+rm -rf "$TMP_DIR" "$MANIFEST"


### PR DESCRIPTION
## Summary
- add project contribution guidelines in `AGENTS.md`
- create `server/build.sh` script to compile `awserver.jar`
- document build instructions in `README.md`

## Testing
- `./server/build.sh > /tmp/test.log 2>&1`


------
https://chatgpt.com/codex/tasks/task_e_686957a713208328a922735062c6a2a3